### PR TITLE
use hypercore's default encoding underneath the Header

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,9 +144,14 @@ HyperTrie.prototype._ready = function (cb) {
 }
 
 HyperTrie.getMetadata = function (feed, cb) {
-  feed.get(0, { valueEncoding: Header }, (err, header) => {
+  feed.get(0, (err, msg) => {
     if (err) return cb(err)
-    return cb(null, header.metadata)
+    try {
+      var header = Header.decode(msg)
+      return cb(null, header.metadata)
+    } catch (err) {
+      return cb(err)
+    }
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -148,10 +148,8 @@ HyperTrie.getMetadata = function (feed, cb) {
     if (err) return cb(err)
     try {
       var header = Header.decode(msg)
-      return cb(null, header.metadata)
-    } catch (err) {
-      return cb(err)
-    }
+    } catch (err) { return cb(err) }
+    return cb(null, header.metadata)
   })
 }
 


### PR DESCRIPTION
with kappa-drive we're using a crypto-encoder on all our hypercores. hypercore prioritises the valueEncoding option passed in get over global valueEncoding options. In this case then, our crypto encoder was ignored and we were getting an error.

This fix uses the default encoding in `feed.get` before then attempting to decode the header.