### PR TITLE
Add headerType option for configuring the feed header type

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Create a new database. Options include:
 {
   feed: aHypercore, // use this feed instead of loading storage
   valueEncoding: 'json', // set value encoding
+  headerSubtype: undefined, // set subtype in the header message at feed.get(0) 
   alwaysUpdate: true // perform an ifAvailable update prior to every head operation
 }
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Create a new database. Options include:
 {
   feed: aHypercore, // use this feed instead of loading storage
   valueEncoding: 'json', // set value encoding
-  headerSubtype: undefined, // set subtype in the header message at feed.get(0) 
+  subtype: undefined, // set subtype in the header message at feed.get(0) 
   alwaysUpdate: true // perform an ifAvailable update prior to every head operation
 }
 ```

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function HyperTrie (storage, key, opts) {
   this.valueEncoding = opts.valueEncoding ? codecs(opts.valueEncoding) : null
   this.alwaysUpdate = !!opts.alwaysUpdate
   this.alwaysReconnect = !!opts.alwaysReconnect
-  this.headerType = opts.headerType || 'hypertrie'
+  this.headerSubtype = opts.headerSubtype
 
   const feedOpts = Object.assign({}, opts, { valueEncoding: 'binary' })
   this.feed = opts.feed || hypercore(storage, key, feedOpts)
@@ -98,7 +98,11 @@ HyperTrie.prototype._ready = function (cb) {
     if (err) return done(err)
 
     if (self.feed.length || !self.feed.writable) return done(null)
-    self.feed.append(Header.encode({type: self.headerType, metadata: self.metadata}), done)
+    self.feed.append(Header.encode({
+      type: 'hypertrie',
+      metadata: self.metadata,
+      subtype: this.headerSubtype
+    }), done)
 
     function done (err) {
       if (err) return cb(err)

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ function HyperTrie (storage, key, opts) {
   this.valueEncoding = opts.valueEncoding ? codecs(opts.valueEncoding) : null
   this.alwaysUpdate = !!opts.alwaysUpdate
   this.alwaysReconnect = !!opts.alwaysReconnect
+  this.headerType = opts.headerType || 'hypertrie'
 
   const feedOpts = Object.assign({}, opts, { valueEncoding: 'binary' })
   this.feed = opts.feed || hypercore(storage, key, feedOpts)
@@ -97,7 +98,7 @@ HyperTrie.prototype._ready = function (cb) {
     if (err) return done(err)
 
     if (self.feed.length || !self.feed.writable) return done(null)
-    self.feed.append(Header.encode({type: 'hypertrie', metadata: self.metadata}), done)
+    self.feed.append(Header.encode({type: this.headerType, metadata: self.metadata}), done)
 
     function done (err) {
       if (err) return cb(err)

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function HyperTrie (storage, key, opts) {
   this.valueEncoding = opts.valueEncoding ? codecs(opts.valueEncoding) : null
   this.alwaysUpdate = !!opts.alwaysUpdate
   this.alwaysReconnect = !!opts.alwaysReconnect
-  this.headerSubtype = opts.headerSubtype
+  this.subtype = opts.subtype
 
   const feedOpts = Object.assign({}, opts, { valueEncoding: 'binary' })
   this.feed = opts.feed || hypercore(storage, key, feedOpts)
@@ -101,7 +101,7 @@ HyperTrie.prototype._ready = function (cb) {
     self.feed.append(Header.encode({
       type: 'hypertrie',
       metadata: self.metadata,
-      subtype: this.headerSubtype
+      subtype: this.subtype
     }), done)
 
     function done (err) {

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ HyperTrie.prototype._ready = function (cb) {
     if (err) return done(err)
 
     if (self.feed.length || !self.feed.writable) return done(null)
-    self.feed.append(Header.encode({type: this.headerType, metadata: self.metadata}), done)
+    self.feed.append(Header.encode({type: self.headerType, metadata: self.metadata}), done)
 
     function done (err) {
       if (err) return cb(err)

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -49,6 +49,10 @@ function defineHeader () {
       var len = encodings.bytes.encodingLength(obj.metadata)
       length += 1 + len
     }
+    if (defined(obj.subtype)) {
+      var len = encodings.string.encodingLength(obj.subtype)
+      length += 1 + len
+    }
     return length
   }
 
@@ -65,6 +69,11 @@ function defineHeader () {
       encodings.bytes.encode(obj.metadata, buf, offset)
       offset += encodings.bytes.encode.bytes
     }
+    if (defined(obj.subtype)) {
+      buf[offset++] = 26
+      encodings.string.encode(obj.subtype, buf, offset)
+      offset += encodings.string.encode.bytes
+    }
     encode.bytes = offset - oldOffset
     return buf
   }
@@ -76,7 +85,8 @@ function defineHeader () {
     var oldOffset = offset
     var obj = {
       type: "",
-      metadata: null
+      metadata: null,
+      subtype: ""
     }
     var found0 = false
     while (true) {
@@ -97,6 +107,10 @@ function defineHeader () {
         case 2:
         obj.metadata = encodings.bytes.decode(buf, offset)
         offset += encodings.bytes.decode.bytes
+        break
+        case 3:
+        obj.subtype = encodings.string.decode(buf, offset)
+        offset += encodings.string.decode.bytes
         break
         default:
         offset = skip(prefix & 7, buf, offset)

--- a/schema.proto
+++ b/schema.proto
@@ -2,6 +2,7 @@
 message Header {
   required string type = 1;
   optional bytes metadata = 2;
+  optional string subtype = 3;
 }
 
 message Node {


### PR DESCRIPTION
This is useful for when you're building a more complex data type on top of hypertrie and want to distinguish it at the Header level.

Related to https://github.com/hypercore-protocol/hyperdrive/issues/294